### PR TITLE
Use `URL` in GLTFLoader

### DIFF
--- a/engine/loaders/GLTFLoader.js
+++ b/engine/loaders/GLTFLoader.js
@@ -21,10 +21,13 @@ import {
 
 export class GLTFLoader {
 
-    // Loads the GLTF JSON file and all buffers and images that it references.
-    // It also creates a cache for all future resource loading.
+    /**
+     * Loads the GLTF JSON file and all buffers and images that it references.
+     * It also creates a cache for all future resource loading.
+     * @param {URL} url
+     */
     async load(url) {
-        this.gltfUrl = new URL(url, window.location);
+        this.gltfUrl = url;
         this.gltf = await this.fetchJson(this.gltfUrl);
         this.defaultScene = this.gltf.scene ?? 0;
         this.cache = new Map();

--- a/examples/03-external/03-gltf/main.js
+++ b/examples/03-external/03-gltf/main.js
@@ -11,7 +11,7 @@ const renderer = new UnlitRenderer(canvas);
 await renderer.initialize();
 
 const loader = new GLTFLoader();
-await loader.load('../../../models/monkey/monkey.gltf');
+await loader.load(new URL('../../../models/monkey/monkey.gltf', import.meta.url));
 
 const scene = loader.loadScene(loader.defaultScene);
 if (!scene) {

--- a/examples/05-collision/01-aabb-aabb/main.js
+++ b/examples/05-collision/01-aabb-aabb/main.js
@@ -19,7 +19,7 @@ const renderer = new UnlitRenderer(canvas);
 await renderer.initialize();
 
 const loader = new GLTFLoader();
-await loader.load('scene/scene.gltf');
+await loader.load(new URL('./scene/scene.gltf', import.meta.url));
 
 const scene = loader.loadScene(loader.defaultScene);
 const camera = loader.loadNode('Camera');

--- a/examples/06-animation/01-easing-functions/main.js
+++ b/examples/06-animation/01-easing-functions/main.js
@@ -16,7 +16,7 @@ const renderer = new UnlitRenderer(canvas);
 await renderer.initialize();
 
 const loader = new GLTFLoader();
-await loader.load('scene/scene.gltf');
+await loader.load(new URL('./scene/scene.gltf', import.meta.url));
 
 const scene = loader.loadScene(loader.defaultScene);
 const camera = loader.loadNode('Camera');


### PR DESCRIPTION
`window.location` in ES module has location of ES module not of the caller. Instead let's just expect URL object as input, which allows setting base. Most of the examples already passed URL object, hence they already worked correctly, others were fixed in this PR.