### PR TITLE
Actually set `running` in UpdateSystem

### DIFF
--- a/engine/systems/UpdateSystem.js
+++ b/engine/systems/UpdateSystem.js
@@ -13,6 +13,8 @@ export class UpdateSystem {
             return;
         }
 
+        this.running = true;
+
         this.application.start?.();
 
         this._time = performance.now() / 1000;
@@ -25,6 +27,8 @@ export class UpdateSystem {
         if (!this.running) {
             return;
         }
+
+        this.running = false;
 
         this.application.stop?.();
 


### PR DESCRIPTION
Currently `this.running` was only set to false in constructor and never updated, hence it was not possible to stop the update system.