### PR TITLE
Fixed mesh aabb with loose parts

### DIFF
--- a/engine/core/MeshUtils.js
+++ b/engine/core/MeshUtils.js
@@ -37,7 +37,7 @@ export function mergeAxisAlignedBoundingBoxes(boxes) {
     };
 
     return {
-        ...boxes.reduce(({ min: amin }, { min: bmin }) => ({ min: vec3.min(amin, amin, bmin) }), initial),
-        ...boxes.reduce(({ max: amax }, { max: bmax }) => ({ max: vec3.max(amax, amax, bmax) }), initial),
+        ...boxes.reduce(({ min: amin }, { min: bmin }) => ({ min: vec3.min(amin, amin, bmin)}), initial),
+        ...boxes.reduce(({ max: amax }, { max: bmax }) => ({ max: vec3.max(amax, amax, bmax)}), initial),
     };
 }

--- a/engine/core/MeshUtils.js
+++ b/engine/core/MeshUtils.js
@@ -37,7 +37,7 @@ export function mergeAxisAlignedBoundingBoxes(boxes) {
     };
 
     return {
-        min: boxes.reduce(({ min: amin }, { min: bmin }) => vec3.min(amin, amin, bmin), initial),
-        max: boxes.reduce(({ max: amax }, { max: bmax }) => vec3.max(amax, amax, bmax), initial),
+        ...boxes.reduce(({ min: amin }, { min: bmin }) => ({ min: vec3.min(amin, amin, bmin) }), initial),
+        ...boxes.reduce(({ max: amax }, { max: bmax }) => ({ max: vec3.max(amax, amax, bmax) }), initial),
     };
 }


### PR DESCRIPTION
Previously when meshes had loose parts, merging their aabb threw because reduce changed acccumulator's type.